### PR TITLE
Dependency versioning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,5 +58,5 @@ analysis = jax>=0.4.20
            tqdm>=4.65.0
 
 test = pytest
-       coverage==6.2
-       coverage-badge==1.1.0
+       coverage>=6.2
+       coverage-badge>=1.1.0


### PR DESCRIPTION
The `test` requirements have `coverage` and `coverage-badge` pinned to specific versions. This changes requirements to `>=`.