### PR TITLE
Multiple frank fits: favor pre-processed vis over multiprocessing

### DIFF
--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import multiprocess
 import pickle 
 
-import frank; frank.enable_logging()
+# import frank; frank.enable_logging()
 from frank.constants import deg_to_rad
 from frank.utilities import jy_convert
 from frank.debris_fitters import FrankDebrisFitter
@@ -371,7 +371,7 @@ def run_frank(model):
         frank fit solutions for each set of hyperparameters 
         (see frank.radial_fitters.FrankFitter)
     """
-    print(' Frank fit: running fit')
+    print(' Frank fit: running fit(s)')
 
     uv_data = input_output.get_vis(model)
 
@@ -485,11 +485,14 @@ def run_frank(model):
         return sol
 
     nfits = len((model["frank"]["alpha"])) * len(model["frank"]["wsmooth"]) * len(hs)
+    print(f"    {nfits} frank fits will be performed")
+
     if nfits == 1:
         sol = frank_fitter([model["frank"]["alpha"][0], model["frank"]["wsmooth"][0], hs[0]])
         return sol
     
     else: 
+        # commenting in favor of approach that saves compute by pre-processing visibilities
         # use as many threads as there are fits, up to a maximum of 'model["frank"]["nthreads"]'
         # nthreads = min(nfits, model["frank"]["nthreads"])
         # pool = multiprocess.Pool(processes=nthreads)
@@ -498,12 +501,12 @@ def run_frank(model):
         #                                                                                      multiprocess.cpu_count())
         #                                                                                      )
 
-        # # grids of prior values
+        # grids of prior values
         g0, g1, g2 = np.meshgrid(model["frank"]["alpha"], model["frank"]["wsmooth"], hs)
         g0, g1, g2 = g0.flatten(), g1.flatten(), g2.flatten()
         priors = np.array([g0, g1, g2]).T
 
-        # # run fits over grids
+        # run fits over grids
         # sols = pool.map(frank_fitter, priors)
 
         sols = []       

--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -506,19 +506,18 @@ def run_frank(model):
         # # run fits over grids
         # sols = pool.map(frank_fitter, priors)
 
-        sols = []
-        for ii in priors[0]:
-            for jj in priors[1]:
-                sol = frank_fitter([ii, jj, hs[0]])
+        sols = []       
+        for prior in priors:            
+            sol = frank_fitter(prior)
 
-                if hs[0] == 0:
-                    logev = None
-                else:
-                    logev = FF.log_evidence_laplace()
-                # add evidence to sol
-                setattr(sol, 'logevidence', logev)
+            if hs[0] == 0:
+                logev = None
+            else:
+                logev = FF.log_evidence_laplace()
+            # add evidence to sol
+            setattr(sol, 'logevidence', logev)
 
-                sols.append(sol)
+            sols.append(sol)
 
         logevs = []
         for ss in sols:

--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -418,8 +418,7 @@ def run_frank(model):
         FF = FrankDebrisFitter(Rmax=model["frank"]["rout"], 
                                 N=model["frank"]["N"], 
                                 geometry=frank_geom,
-                                scale_height=None, # TODO: just for pre-processed visibilities
-                                # scale_height=scale_height, # TODO
+                                scale_height=scale_height,
                                 alpha=alpha,
                                 weights_smooth=wsmooth,
                                 method=model["frank"]["method"],
@@ -428,7 +427,10 @@ def run_frank(model):
                                 convergence_failure='warn'
                                 )
 
-        sol = FF.fit_preprocessed(ppV)
+        if scale_height is None:
+            sol = FF.fit_preprocessed(ppV)
+        else:
+            sol = FF.fit(*uv_data)
 
         # add non-negative brightness profile to sol
         if model["frank"]["method"] == "Normal":

--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import multiprocess
 import pickle 
 
+import frank; frank.enable_logging()
 from frank.constants import deg_to_rad
 from frank.utilities import jy_convert
 from frank.debris_fitters import FrankDebrisFitter
@@ -485,7 +486,6 @@ def run_frank(model):
 
     nfits = len((model["frank"]["alpha"])) * len(model["frank"]["wsmooth"]) * len(hs)
     if nfits == 1:
-        # import frank; frank.enable_logging()
         sol = frank_fitter([model["frank"]["alpha"][0], model["frank"]["wsmooth"][0], hs[0]])
         return sol
     

--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -482,13 +482,13 @@ def run_frank(model):
                                          save_prefix=save_prefix
                                          )
 
-        return sol
+        return sol, FF
 
     nfits = len((model["frank"]["alpha"])) * len(model["frank"]["wsmooth"]) * len(hs)
     print(f"    {nfits} frank fits will be performed")
 
     if nfits == 1:
-        sol = frank_fitter([model["frank"]["alpha"][0], model["frank"]["wsmooth"][0], hs[0]])
+        sol, _ = frank_fitter([model["frank"]["alpha"][0], model["frank"]["wsmooth"][0], hs[0]])
         return sol
     
     else: 
@@ -511,7 +511,7 @@ def run_frank(model):
 
         sols = []       
         for prior in priors:            
-            sol = frank_fitter(prior)
+            sol, FF = frank_fitter(prior)
 
             if hs[0] == 0:
                 logev = None

--- a/arksia/pipeline.py
+++ b/arksia/pipeline.py
@@ -383,29 +383,27 @@ def run_frank(model):
     # set scale height
     if model["frank"]["scale_heights"] is None:
         hs = [0]
+
+        # pre-process visibilities for multiple frank fits (only valid for a 
+        # fixed scale height
+        FF_pre = FrankDebrisFitter(Rmax=model["frank"]["rout"], 
+                                N=model["frank"]["N"], 
+                                geometry=frank_geom,
+                                scale_height=None,
+                                alpha=0,
+                                weights_smooth=0,
+                                method=model["frank"]["method"],
+                                I_scale=model["frank"]["I_scale"],
+                                max_iter=model["frank"]["max_iter"],
+                                convergence_failure='warn'
+                                )
+        ppV = FF_pre.preprocess_visibilities(*uv_data)
+
     else:
         hs = np.logspace(*model["frank"]["scale_heights"])
-        print("    aspect ratios to be sampled: {}".format(hs))          
-    
-    # pre-process visibilities for multiple frank fits.
-    # Re-using the processed visibilities is only valid with certain parameter
-    # changes. For example N, Rmax, geometry, nu, assume_optically_thick, and
-    # scale_height cannot be changed. This will be checked before fits are 
-    # conducted.        
-    FF = FrankDebrisFitter(Rmax=model["frank"]["rout"], 
-                            N=model["frank"]["N"], 
-                            geometry=frank_geom,
-                            scale_height=None, # TODO
-                            alpha=0,
-                            weights_smooth=0,
-                            method=model["frank"]["method"],
-                            I_scale=model["frank"]["I_scale"],
-                            max_iter=model["frank"]["max_iter"],
-                            convergence_failure='warn'
-                            )
-    ppV = FF.preprocess_visibilities(*uv_data)
+        print("    aspect ratios to be sampled: {}".format(hs))
 
-    # # perform frank fit(s)
+    # perform frank fit(s)
     def frank_fitter(priors):
         alpha, wsmooth, h = priors 
         print('        performing fit for alpha {} wsmooth {} h {}'.format(alpha, wsmooth, h))

--- a/arksia/plot.py
+++ b/arksia/plot.py
@@ -459,9 +459,11 @@ def frank_multifit_figure(model, sols, plot_var, single_panel=False, save_prefix
     save_prefix : str, default = None
         Prefix for saved figure name. If None, the figure won't be saved
     """
-    print('  Figures: making multifit grid figure')
-
-    nsols = len(sols)
+    if single_panel is True:
+        fig_layout = "single_panel"
+    else:
+        fig_layout = "grid"
+    print(f"  Figures: making multifit figure: {fig_layout} of {plot_var}")
 
     if single_panel is True:
         fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(10,8))


### PR DESCRIPTION
Running many `LogNormal` frank fits can be slow with multiprocessing; it saves compute to recycle the pre-processed visibilities for multiple fits without a varying scale height. PR implements this.